### PR TITLE
Remove OS_TIME_TICK definition. We only really need one definition fo…

### DIFF
--- a/libs/os/include/os/arch/cortex_m4/os/os_arch.h
+++ b/libs/os/include/os/arch/cortex_m4/os/os_arch.h
@@ -27,8 +27,7 @@ struct os_task;
 #define OS_RUN_PRIV         (1)
 
 /* Time tick in miliseconds that the OS runs */
-#define OS_TIME_TICK        (1)
-#define OS_TICKS_PER_SEC    (OS_TIME_TICK * 1000)
+#define OS_TICKS_PER_SEC    (1000)
 
 /* CPU status register */
 typedef uint32_t os_sr_t;

--- a/libs/os/include/os/arch/sim/os/os_arch.h
+++ b/libs/os/include/os/arch/sim/os/os_arch.h
@@ -20,9 +20,7 @@
 struct os_task;
 
 /* Time tick in miliseconds that the OS runs */
-
-#define OS_TIME_TICK (1)
-#define OS_TICKS_PER_SEC (OS_TIME_TICK * 1000)
+#define OS_TICKS_PER_SEC (1000)
 
 /* CPU status register */
 typedef unsigned int os_sr_t;

--- a/libs/os/src/arch/cortex_m4/os_arch_arm.c
+++ b/libs/os/src/arch/cortex_m4/os_arch_arm.c
@@ -218,8 +218,10 @@ os_arch_os_init(void)
 
 /**
  * os systick init
- *
+ *  
  * Initializes systick for the MCU
+ * 
+ * @param os_tick_usecs The number of microseconds in an os time tick
  */
 static void
 os_systick_init(uint32_t os_tick_usecs)
@@ -250,8 +252,7 @@ os_arch_start(void)
     __set_PSP((uint32_t)t->t_stackptr + offsetof(struct stack_frame, r0));
 
     /* Intitialize and start system clock timer */
-
-    os_systick_init(OS_TIME_TICK * 1000);
+    os_systick_init(1000000 / OS_TICKS_PER_SEC);
 
     /* Mark the OS as started, right before we run our first task */
     g_os_started = 1;


### PR DESCRIPTION
…r the amount of time of one os time tick (and that is OS_TICKS_PER_SEC)