### PR TITLE
Remove c_flags from os_callout; instead use info whether c_next is fi…

### DIFF
--- a/libs/os/include/os/os_callout.h
+++ b/libs/os/include/os/os_callout.h
@@ -19,13 +19,10 @@
 #define _OS_CALLOUT_H
 
 #define OS_CALLOUT_F_QUEUED (0x01)
-#define OS_CALLOUT_QUEUED(__c) ((__c)->c_flags & OS_CALLOUT_F_QUEUED)
 
 struct os_callout {
     struct os_event c_ev;
     struct os_eventq *c_evq;
-    uint8_t c_flags;
-    uint8_t _pad[3];
     uint32_t c_ticks;
     TAILQ_ENTRY(os_callout) c_next;
 };
@@ -45,6 +42,11 @@ void os_callout_stop(struct os_callout *);
 int os_callout_reset(struct os_callout *, int32_t);
 void os_callout_tick(void);
 
+static inline int
+os_callout_queued(struct os_callout *c)
+{
+    return c->c_next.tqe_prev != NULL;
+}
 #endif /* _OS_CALLOUT_H */
 
 

--- a/libs/os/include/os/os_eventq.h
+++ b/libs/os/include/os/os_eventq.h
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -14,28 +14,24 @@
  * limitations under the License.
  */
 
-#ifndef _OS_EVENTQ_H 
-#define _OS_EVENTQ_H 
+#ifndef _OS_EVENTQ_H
+#define _OS_EVENTQ_H
 
-struct os_event { 
-    uint8_t ev_queued; 
+struct os_event {
+    uint8_t ev_queued;
     uint8_t ev_type;
     void *ev_arg;
-    TAILQ_ENTRY(os_event) ev_next; 
+    STAILQ_ENTRY(os_event) ev_next;
 };
 
-#define OS_EVENT_QUEUED(__ev) ((__ev)->ev_queued) 
-
-#define OS_EVENT_INITIALIZER(ev, __type, __arg) { \
-    0, (__type), (__arg), { NULL } \
-}
+#define OS_EVENT_QUEUED(__ev) ((__ev)->ev_queued)
 
 #define OS_EVENT_T_TIMER (1)
-#define OS_EVENT_T_PERUSER (16) 
+#define OS_EVENT_T_PERUSER (16)
 
 struct os_eventq {
     struct os_task *evq_task;
-    TAILQ_HEAD(, os_event) evq_list;
+    STAILQ_HEAD(, os_event) evq_list;
 };
 
 void os_eventq_init(struct os_eventq *);

--- a/libs/os/src/os_callout.c
+++ b/libs/os/src/os_callout.c
@@ -46,9 +46,9 @@ os_callout_stop(struct os_callout *c)
 
     OS_ENTER_CRITICAL(sr);
 
-    if (OS_CALLOUT_QUEUED(c)) {
+    if (os_callout_queued(c)) {
         TAILQ_REMOVE(&g_callout_list, c, c_next);
-        c->c_flags &= ~OS_CALLOUT_F_QUEUED;
+        c->c_next.tqe_prev = NULL;
     }
 
     if (c->c_evq) {
@@ -79,7 +79,6 @@ os_callout_reset(struct os_callout *c, int32_t ticks)
     }
 
     c->c_ticks = os_time_get() + ticks;
-    c->c_flags |= OS_CALLOUT_F_QUEUED;
 
     entry = NULL;
     TAILQ_FOREACH(entry, &g_callout_list, c_next) {
@@ -116,7 +115,7 @@ os_callout_tick(void)
         if (c) {
             if (OS_TIME_TICK_GEQ(now, c->c_ticks)) {
                 TAILQ_REMOVE(&g_callout_list, c, c_next);
-                c->c_flags &= ~OS_CALLOUT_F_QUEUED;
+                c->c_next.tqe_prev = NULL;
             } else {
                 c = NULL;
             }


### PR DESCRIPTION
…lled

in instead.
Change os_event linkage to be STAILQ instead of TAILQ.