### PR TITLE
Add API to get packet header mbuf

### DIFF
--- a/libs/os/include/os/os_mbuf.h
+++ b/libs/os/include/os/os_mbuf.h
@@ -194,6 +194,10 @@ int os_mbuf_pool_init(struct os_mbuf_pool *, struct os_mempool *mp, uint16_t,
 
 /* Allocate a new mbuf out of the os_mbuf_pool */ 
 struct os_mbuf *os_mbuf_get(struct os_mbuf_pool *omp, uint16_t);
+
+/* Allocate a new packet header mbuf out of the os_mbuf_pool */ 
+struct os_mbuf *os_mbuf_get_pkthdr(struct os_mbuf_pool *omp);
+
 /* Duplicate a mbuf from the pool */
 struct os_mbuf *os_mbuf_dup(struct os_mbuf_pool *omp, struct os_mbuf *m);
 
@@ -203,6 +207,7 @@ int os_mbuf_append(struct os_mbuf_pool *omp, struct os_mbuf *m, void *,
 
 /* Free a mbuf */
 int os_mbuf_free(struct os_mbuf_pool *omp, struct os_mbuf *mb);
+
 /* Free a mbuf chain */
 int os_mbuf_free_chain(struct os_mbuf_pool *omp, struct os_mbuf *om);
 

--- a/libs/os/src/os_mbuf.c
+++ b/libs/os/src/os_mbuf.c
@@ -90,7 +90,7 @@ os_mbuf_pool_init(struct os_mbuf_pool *omp, struct os_mempool *mp,
 struct os_mbuf * 
 os_mbuf_get(struct os_mbuf_pool *omp, uint16_t leadingspace)
 {
-    struct os_mbuf *om; 
+    struct os_mbuf *om;
 
     om = os_memblock_get(omp->omp_pool);
     if (!om) {
@@ -105,6 +105,21 @@ os_mbuf_get(struct os_mbuf_pool *omp, uint16_t leadingspace)
     return (om);
 err:
     return (NULL);
+}
+
+/* Allocate a new packet header mbuf out of the os_mbuf_pool */ 
+struct os_mbuf *
+os_mbuf_get_pkthdr(struct os_mbuf_pool *omp)
+{
+    struct os_mbuf *om;
+
+    om = os_mbuf_get(omp, 0);
+    if (om) {
+        om->om_flags |= OS_MBUF_F_MASK(OS_MBUF_F_PKTHDR);
+        om->om_data += omp->omp_hdr_len + sizeof(struct os_mbuf_pkthdr);
+    }
+
+    return om;
 }
 
 /**


### PR DESCRIPTION
I did not see an API to get a packet header mbuf so I added one. In looking at my changes I noticed that I could probably just set the flags instead of read-modify-write. I will update that code in a separate commit if the changes look good. Note that I also presume that we will modify the os_mbuf_get() API to remove leadingspace, which is why I did not add it to the os_mbuf_get_pkthdr() API.